### PR TITLE
Upgrade to .NET Core 2.2 and compiled regexes

### DIFF
--- a/csharp/Benchmark.cs
+++ b/csharp/Benchmark.cs
@@ -30,7 +30,7 @@ class Benchmark
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
 
-        MatchCollection matches = Regex.Matches(data, pattern);
+        MatchCollection matches = Regex.Matches(data, pattern, RegexOptions.Compiled);
         int count = matches.Count;
 
         stopwatch.Stop();

--- a/csharp/benchmark.csproj
+++ b/csharp/benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/run-benchmarks.php
+++ b/run-benchmarks.php
@@ -21,7 +21,7 @@ const COMMANDS = [
     'C PCRE2'      => 'c/bin/benchmark',
     'Crystal'      => 'crystal/bin/benchmark',
     'C# Mono'      => 'mono -O=all csharp/bin-mono/benchmark.exe',
-    'C# .Net Core' => 'dotnet csharp/bin/Release/netcoreapp2.0/benchmark.dll',
+    'C# .Net Core' => 'dotnet csharp/bin/Release/netcoreapp2.2/benchmark.dll',
     'D dmd'        => 'd/bin/benchmark',
     'D ldc'        => 'd/bin/benchmark-ldc',
     'Go'           => 'go/bin/benchmark',


### PR DESCRIPTION
.NET Core 2.0 is out of support, so moving to latest 2.2
.NET Core 2.1 added support for compiled regexes (same as .NET Framework) so I'm reenabling that. Although .NET still trails the pack, this roughly doubles performance.