### PR TITLE
Add C++ Boost.Regex benchmark

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN curl -sSL https://dist.crystal-lang.org/apt/setup.sh | bash && \
     apt-get install -yq --no-install-recommends \
         crystal
 
+## C++
+RUN apt-get install -yq --no-install-recommends \
+        libboost-regex-dev
+
 ## C# Mono
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
     echo "deb https://download.mono-project.com/repo/ubuntu stable-bionic main" | tee /etc/apt/sources.list.d/mono-official-stable.list && \

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Language | Email(ms) | URI(ms) | IP(ms) | Total(ms)
 
 - **C**: gcc 7.4.0 & PCRE2 10.31-2
 - **Crystal**: crystal 0.31.1 - LLVM: 8.0.0
-- **C++**: g++ 7.4.0 
+- **C++**: g++ 7.4.0 | Boost 1.65.0
 - **C#**: dotnet 3.0.100 | Mono 6.4.0.198
 - **D**: DMD v2.089.0 | LDC 1.8.0
 - **Dart**: Dart 2.6.1

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -3,11 +3,13 @@
 ## How to build
 
 ```sh
-g++ -std=c++11 -O3 benchmark.cpp -o bin/benchmark
+g++ -std=c++11 -O3 benchmark.cpp -lboost_regex -o bin/benchmark-stl -DREGEX_NAMESPACE=std
+g++ -std=c++11 -O3 benchmark.cpp -lboost_regex -o bin/benchmark-boost -DREGEX_NAMESPACE=boost
 ```
 
 ## How to run
 
 ```sh
-./bin/benchmark <filename>
+./bin/benchmark-stl <filename>
+./bin/benchmark-boost <filename>
 ```

--- a/cpp/benchmark.cpp
+++ b/cpp/benchmark.cpp
@@ -2,15 +2,16 @@
 #include <fstream>
 #include <iostream>
 #include <regex>
+#include <boost/regex.hpp>
 
 void measure(const std::string& data, const std::string& pattern) {
   using clock = std::chrono::high_resolution_clock;
   const auto start = clock::now();
 
-  const std::regex re{pattern};
+  const REGEX_NAMESPACE::regex re{pattern};
   unsigned count = 0;
 
-  for (std::sregex_token_iterator it{data.cbegin(), data.cend(), re}, end{}; it != end; ++it)
+  for (REGEX_NAMESPACE::sregex_token_iterator it{data.cbegin(), data.cend(), re}, end{}; it != end; ++it)
     count++;
 
   const auto end = clock::now();

--- a/run-benchmarks.php
+++ b/run-benchmarks.php
@@ -7,7 +7,8 @@ const RUN_TIMES = 10;
 const BUILDS = [
     'C PCRE2'      => 'gcc -O3 -DNDEBUG c/benchmark.c -I/usr/local/include/ -lpcre2-8 -o c/bin/benchmark',
     'Crystal'      => 'crystal build crystal/benchmark.cr --release -o crystal/bin/benchmark',
-    'C++'          => 'g++ -std=c++11 -O3 cpp/benchmark.cpp -o cpp/bin/benchmark',
+    'C++ - STL'    => 'g++ -std=c++11 -O3 cpp/benchmark.cpp -DREGEX_NAMESPACE=std -lboost_regex -o cpp/bin/benchmark-stl',
+    'C++ - Boost'  => 'g++ -std=c++11 -O3 cpp/benchmark.cpp -DREGEX_NAMESPACE=boost -lboost_regex -o cpp/bin/benchmark-boost',
     'C# Mono'      => 'mcs csharp/Benchmark.cs -out:csharp/bin-mono/benchmark.exe -debug- -optimize',
     'C# .Net Core' => 'dotnet build csharp/benchmark.csproj -c Release',
     'D dmd'        => 'dmd -O -release -inline -of=d/bin/benchmark d/benchmark.d',
@@ -22,7 +23,8 @@ const BUILDS = [
 const COMMANDS = [
     'C PCRE2'      => 'c/bin/benchmark',
     'Crystal'      => 'crystal/bin/benchmark',
-    'C++'          => 'cpp/bin/benchmark',
+    'C++ STL'      => 'cpp/bin/benchmark-stl',
+    'C++ Boost'    => 'cpp/bin/benchmark-boost',
     'C# Mono'      => 'mono -O=all csharp/bin-mono/benchmark.exe',
     'C# .Net Core' => 'dotnet csharp/bin/Release/netcoreapp3.0/benchmark.dll',
     'D dmd'        => 'd/bin/benchmark',


### PR DESCRIPTION
Closes #16 

I decided not to add CTRE, because it needs a newer compiler than is available in Ubuntu 18.04, so setting that up would require a new PPA to be enabled and frankly I just couldn't have been bothered.

Like I said, `boost::regex` is API compatible with `std::regex`, so instead of creating two files, I made the namespace a macro. The regex implementation can be chosen on the command line with `-DREGEX_NAMESPACE=std` or `-DREGEX_NAMESPACE=boost`.

Finally, the benchmark table update is missing, because docker kept dying while installing the javascript requirements and I also can't `docker push`, but I have updated the `Dockerfile`.