### PR TITLE
csharp: move regex compilation outside of measure

### DIFF
--- a/csharp/Benchmark.cs
+++ b/csharp/Benchmark.cs
@@ -28,9 +28,11 @@ class Benchmark
 
     static void Measure(string data, string pattern)
     {
+        Regex regex = new Regex(pattern, RegexOptions.Compiled);
+
         Stopwatch stopwatch = Stopwatch.StartNew();
 
-        MatchCollection matches = Regex.Matches(data, pattern, RegexOptions.Compiled);
+        MatchCollection matches = regex.Matches(data);
         int count = matches.Count;
 
         stopwatch.Stop();


### PR DESCRIPTION
In general using `RegexOptions.Compile` has a negative effect, that's amortized since usually we compile regex state machine only once and reuse object created this way between pattern tests. For this reason I think it should be moved outside of the measurement.