### PR TITLE
Disable Unicode support for C# to match Java, Rust, C, C++

### DIFF
--- a/csharp/Benchmark.cs
+++ b/csharp/Benchmark.cs
@@ -30,7 +30,8 @@ class Benchmark
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
 
-        MatchCollection matches = Regex.Matches(data, pattern);
+        MatchCollection matches = Regex.Matches(data, pattern, RegexOptions.Compiled | RegexOptions.ECMAScript); // No unicode, to match other benchmarks
+
         int count = matches.Count;
 
         stopwatch.Stop();


### PR DESCRIPTION
The C benchmark does not enable Unicode support (it doesn't pass `PCRE_UTF*` option) nor does the C++ Boost benchmark (it doesn't use `u32regex`) and Java doesn't either (it doesn't set `Pattern.UNICODE_CHARACTER_CLASS` nor add the `?U` option). Rust (since https://github.com/mariomka/regex-benchmark/pull/21) explicitly passes `.unicode(false)`.

C# however is laboring with matching Unicode character classes. To be fair, this adds RegexOptions.ECMAScript. The flag has [other effects](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-options?view=netcore-3.1#ecmascript-matching-behavior), but disabling Unicode is the only effect that is relevant to this benchmark - the other ones relate to aspects of the pattern that aren't present in this benchmark's patterns.

This increases C# perf by about ~45% on 3.1. It's still some distance off Rust/C/C++ but it brings it in line with Java (at least with the improvements in .NET 5.0) which is nice.

cc @stephentoub
