### PR TITLE
Optimize C#

### DIFF
--- a/csharp/Benchmark.cs
+++ b/csharp/Benchmark.cs
@@ -30,7 +30,7 @@ class Benchmark
     {
         Stopwatch stopwatch = Stopwatch.StartNew();
 
-        MatchCollection matches = Regex.Matches(data, pattern);
+        MatchCollection matches = Regex.Matches(data, pattern, RegexOptions.Compiled | RegexOptions.ECMAScript | RegexOptions.CultureInvariant);
         int count = matches.Count;
 
         stopwatch.Stop();

--- a/csharp/benchmark.csproj
+++ b/csharp/benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
RegexOptions.Compiled just makes it faster.
RegexOptions.ECMAScript disables Unicode support, which makes it faster still.
RegexOptions.CultureInvariant causes comparisons to use the invariant culture, which appears to make a small improvement.
None of these options affect the count of matches.

relates to https://github.com/mariomka/regex-benchmark/issues/27