### PR TITLE
Add nim-regex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && \
         software-properties-common \
         tzdata \
         unzip \
-        wget
+        wget \
+        git
 
 # Set the locale and timezone
 RUN locale-gen en_US.UTF-8 && \
@@ -92,7 +93,8 @@ RUN wget -q https://github.com/JetBrains/kotlin/releases/download/v1.3.50/kotlin
 
 ## Nim
 RUN curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y && \
-    ln -s /root/.nimble/bin/nim /usr/local/bin/nim
+    ln -s /root/.nimble/bin/nim /usr/local/bin/nim && \
+    ln -s /root/.nimble/bin/nimble /usr/local/bin/nimble
 
 ## PHP
 RUN apt-get install -yq --no-install-recommends \

--- a/nim/benchmark_regex.nim
+++ b/nim/benchmark_regex.nim
@@ -1,0 +1,25 @@
+import times
+import os
+import strformat
+
+import pkg/regex
+
+if paramCount() == 0:
+  echo "Usage: ./benchmark <filename>"
+  quit(QuitFailure)
+
+proc measure(data: string, pattern: string) =
+  let time = cpuTime()
+  let r_pattern = re(pattern)
+  let matches = data.findAll(r_pattern)
+  let count = len(matches)
+  let elapsed_time = cpuTime() - time 
+  echo &"{elapsed_time * 1e3} - {count}"
+
+let data = readFile(paramStr(1))
+
+measure(data, r"[\w\.+-]+@[\w\.-]+\.[\w\.-]+")
+
+measure(data, r"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?")
+
+measure(data, r"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])")

--- a/run-benchmarks.php
+++ b/run-benchmarks.php
@@ -18,6 +18,7 @@ const BUILDS = [
     'Java'         => 'javac java/Benchmark.java',
     'Kotlin'       => 'kotlinc kotlin/benchmark.kt -include-runtime -d kotlin/benchmark.jar',
     'Nim'          => 'nim c -d:release --opt:speed --verbosity:0 -o:nim/bin/benchmark nim/benchmark.nim',
+    'Nim Regex'    => 'nimble install regex -y && nim c -d:danger --verbosity:0 -o:nim/bin/benchmark_regex nim/benchmark_regex.nim',
     'Rust'         => 'cargo build --quiet --release --manifest-path=rust/Cargo.toml',
 ];
 
@@ -37,6 +38,7 @@ const COMMANDS = [
     'Javascript'   => 'node javascript/benchmark.js',
     'Kotlin'       => 'kotlin kotlin/benchmark.jar',
     'Nim'          => 'nim/bin/benchmark',
+    'Nim Regex'    => 'nim/bin/benchmark_regex',
     'Perl'         => 'perl perl/benchmark.pl',
     'PHP'          => 'php php/benchmark.php',
     'Python 2'     => 'python2.7 python/benchmark.py',


### PR DESCRIPTION
Hola,

Este PR agrega la libreria [nim-regex](https://github.com/nitely/nim-regex) a los benchmarks. Es una libreria escrita enteramente en Nim. El codigo del benchmark es practicamente el mismo que se usa para el modulo `re` de nim.