### PR TITLE
Add Julia implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,9 +84,9 @@ RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - && \
         nodejs
 
 ## Julia
-RUN wget -q https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.2-linux-x86_64.tar.gz -O julia-1.5.2-linux-x86_64.tar.gz && \
-    tar -x -C /opt -f julia-1.5.2-linux-x86_64.tar.gz && \
-    mv /opt/julia-1.5.2 /opt/julia && \
+RUN wget -q https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.3-linux-x86_64.tar.gz -O julia-1.5.3-linux-x86_64.tar.gz && \
+    tar -x -C /opt -f julia-1.5.3-linux-x86_64.tar.gz && \
+    mv /opt/julia-1.5.3 /opt/julia && \
     ln -s /opt/julia/bin/julia /usr/local/bin/julia
 
 ## Kotlin

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,12 @@ RUN curl -sL https://deb.nodesource.com/setup_13.x | bash - && \
     apt-get install -yq --no-install-recommends \
         nodejs
 
+## Julia
+RUN wget -q https://julialang-s3.julialang.org/bin/linux/x64/1.5/julia-1.5.2-linux-x86_64.tar.gz -O julia-1.5.2-linux-x86_64.tar.gz && \
+    tar -x -C /opt -f julia-1.5.2-linux-x86_64.tar.gz && \
+    mv /opt/julia-1.5.2 /opt/julia && \
+    ln -s /opt/julia/bin/julia /usr/local/bin/julia
+
 ## Kotlin
 RUN wget -q https://github.com/JetBrains/kotlin/releases/download/v1.3.50/kotlin-compiler-1.3.50.zip -O kotlin-compiler-1.3.50.zip && \
     unzip kotlin-compiler-1.3.50.zip -d /opt/ && \

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Language | Email(ms) | URI(ms) | IP(ms) | Total(ms)
 - **Go**: go 1.14.2
 - **Java**: OpenJDK 11.0.7
 - **Javascript**: node v13.14.0
+- **Julia**: Julia 1.5.2
 - **Kotlin**: kotlinc-jvm 1.3.50
 - **Nim**: Nim 1.2.0
 - **Perl**: perl v5.26.1

--- a/julia/README.md
+++ b/julia/README.md
@@ -1,0 +1,7 @@
+# Julia Regex Benchmark
+
+## How to run
+
+```sh
+julia benchmark.jl <filename>
+```

--- a/julia/benchmark.jl
+++ b/julia/benchmark.jl
@@ -1,0 +1,19 @@
+function measure(data, pattern)
+    start = time()
+    count = length(collect(eachmatch(pattern, data)))
+    elapsed = time() - start
+    elapsed_ms = 1000 * elapsed
+
+    println(string(elapsed_ms) * " - " * string(count))
+end
+
+if length(ARGS) < 1
+    println("Usage: julia benchmark.jl <filename>")
+    exit(1)
+end
+
+data = open(f->read(f, String), ARGS[1])
+
+measure(data, r"[\w.+-]+@[\w.-]+\.[\w.-]+")
+measure(data, r"[\w]+://[^/\s?#]+[^\s?#]+(?:\?[^\s#]*)?(?:#[^\s]*)?")
+measure(data, r"(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])")

--- a/run-benchmarks.php
+++ b/run-benchmarks.php
@@ -35,6 +35,7 @@ const COMMANDS = [
     'Go'           => 'go/bin/benchmark',
     'Java'         => 'java -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -classpath java Benchmark',
     'Javascript'   => 'node javascript/benchmark.js',
+    'Julia'        => 'julia julia/benchmark.jl',
     'Kotlin'       => 'kotlin kotlin/benchmark.jar',
     'Nim'          => 'nim/bin/benchmark',
     'Perl'         => 'perl perl/benchmark.pl',


### PR DESCRIPTION
Thanks for this useful repository. I've added a naive Julia implementation.

This currently does not build do to the PyPy implementations failing. I've dropped those in a [separate commit](https://github.com/mariomka/regex-benchmark/compare/master...szarnyasg:drop-pypy?expand=1), which can be merged if needed.

Here are the numbers on my laptop:

```
- Results
**PHP** | 23.15 | 22.86 | 7.39 | 53.40
**Nim** | 23.40 | 23.35 | 7.37 | 54.12
**Javascript** | 66.52 | 53.23 | 1.55 | 121.31
**Rust** | 58.81 | 60.13 | 5.59 | 124.53
**Julia** | 67.72 | 48.17 | 9.00 | 124.88 <---------------------------------------
**C++ Boost** | 80.29 | 80.10 | 26.32 | 186.72
**Perl** | 106.98 | 77.47 | 50.91 | 235.36
**Dart** | 124.80 | 132.88 | 128.38 | 386.07
**C PCRE2** | 275.86 | 260.15 | 31.88 | 567.89
**Crystal** | 306.31 | 278.15 | 24.61 | 609.07
**Ruby** | 368.44 | 336.87 | 57.60 | 762.91
**D dmd** | 373.31 | 394.86 | 8.71 | 776.88
**D ldc** | 415.53 | 426.94 | 8.11 | 850.57
**Go** | 331.22 | 330.65 | 553.31 | 1215.18
**Java** | 218.86 | 279.64 | 724.56 | 1223.06
**Kotlin** | 235.63 | 280.08 | 720.09 | 1235.79
**Python 2** | 800.38 | 295.01 | 1068.39 | 2163.78
**Python 3** | 938.16 | 312.98 | 1037.45 | 2288.59
**C++ STL** | 822.71 | 707.50 | 943.89 | 2474.09
**C# Mono** | 4070.49 | 3496.08 | 181.43 | 7748.00
```