### PR TITLE
Add CL version

### DIFF
--- a/common_lisp/.gitignore
+++ b/common_lisp/.gitignore
@@ -1,0 +1,2 @@
+quicklisp.lisp
+quicklisp

--- a/common_lisp/README.md
+++ b/common_lisp/README.md
@@ -1,0 +1,13 @@
+# C++ Benchmark
+
+## How to build
+
+```sh
+./quicklisp.sh
+```
+
+## How to run
+
+```sh
+sbcl --script benchmark.lisp <filename>
+```

--- a/common_lisp/benchmark.lisp
+++ b/common_lisp/benchmark.lisp
@@ -1,0 +1,17 @@
+;; (declaim (optimize (speed 3) (safety 0)))
+
+(load (merge-pathnames "quicklisp/setup.lisp" *load-truename*))
+(ql:quickload :cl-ppcre :silent t)
+(require :uiop)
+
+(defun measure (data pat)
+  (let* ((scanner (cl-ppcre:create-scanner pat))
+		 (start (get-internal-real-time))
+		 (match-count (cl-ppcre:count-matches scanner data))
+		 (elapsed (- (get-internal-real-time) start)))
+	(format t "~,3f - ~d~%" (* (/ elapsed internal-time-units-per-second) 1e3) match-count)))
+
+(let ((data (uiop:read-file-string (car uiop:*command-line-arguments*))))
+  (measure data "[\\w\\.+-]+@[\\w\\.-]+\\.[\\w\\.-]+")
+  (measure data "[\\w]+://[^/\\s?#]+[^\\s?#]+(?:\\?[^\\s#]*)?(?:#[^\\s]*)?")
+  (measure data "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9])"))

--- a/common_lisp/quicklisp.sh
+++ b/common_lisp/quicklisp.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -eu
+cd -- "$(dirname -- "$0")"
+! [ -f quicklisp.lisp ] &&
+	curl -O https://beta.quicklisp.org/quicklisp.lisp
+! [ -d quicklisp ] &&
+	sbcl --no-userinit --load quicklisp.lisp --eval '(quicklisp-quickstart:install :path "quicklisp")' --quit

--- a/run-benchmarks.php
+++ b/run-benchmarks.php
@@ -6,6 +6,7 @@ const RUN_TIMES = 10;
 
 const BUILDS = [
     'C PCRE2'      => 'gcc -O3 -DNDEBUG c/benchmark.c -I/usr/local/include/ -lpcre2-8 -o c/bin/benchmark',
+	'Common Lisp'  => 'common_lisp/quicklisp.sh'
     'Crystal'      => 'crystal build crystal/benchmark.cr --release -o crystal/bin/benchmark',
     'C++ STL'      => 'g++ -std=c++11 -O3 cpp/benchmark.cpp -o cpp/bin/benchmark-stl',
     'C++ Boost'    => 'g++ -std=c++11 -O3 cpp/benchmark.cpp -DUSE_BOOST -lboost_regex -o cpp/bin/benchmark-boost',
@@ -25,6 +26,7 @@ const BUILDS = [
 
 const COMMANDS = [
     'C PCRE2'      => 'c/bin/benchmark',
+	'Common Lisp'  => 'sbcl --script common_lisp/benchmark.lisp'
     'Crystal'      => 'crystal/bin/benchmark',
     'C++ STL'      => 'cpp/bin/benchmark-stl',
     'C++ Boost'    => 'cpp/bin/benchmark-boost',


### PR DESCRIPTION
Extremely slow, even with maximum optimization. As I'm a bit novice to CL, this may be my fault, but I doubt it, and SBCL storing Unicode text as array of codepoints instead of raw UTF-8 may be a culprit.